### PR TITLE
Remove hard-coded references to *.service.cf.internal and use properties

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -126,12 +126,18 @@ properties:
 
   uaa.clients.gorouter.secret:
     description: "Password for UAA client for the gorouter."
+  uaa.token_endpoint:
+    description: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
   uaa.port:
     description: "Port on which UAA is running."
     default: 8080
   uaa.ssl.port:
     description: "Secure Port on which UAA is running."
 
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
   routing_api.port:
     description: "Port on which Routing API is running."
     default: 3000

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -41,7 +41,7 @@ publish_active_apps_interval: 0 # 0 means disabled
 suspend_pruning_if_nats_unavailable: <%= p("router.suspend_pruning_if_nats_unavailable") %>
 
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   client_name: "gorouter"
   client_secret: <%= p("uaa.clients.gorouter.secret") %>
   port: <%= p("uaa.ssl.port") %>
@@ -52,7 +52,7 @@ oauth:
 
 <% if p("routing_api.enabled") %>
 routing_api:
-  uri: http://routing-api.service.cf.internal
+  uri: <%= p("routing_api.uri") %>
   port: <%= p("routing_api.port") %>
   auth_disabled: <%= p("routing_api.auth_disabled") %>
 <% end %>

--- a/jobs/router_configurer/spec
+++ b/jobs/router_configurer/spec
@@ -25,12 +25,24 @@ properties:
     description: "String representing interval for collecting statistic metrics from tcp proxy. Units: ms, s, m h"
     default: "1m"
 
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
+
+  routing_api.port:
+    description: "Port of routing api"
+    default: "3000"
+
   routing_api.auth_disabled:
     description: "When false, Routing API requires OAuth tokens for authentication."
     default: false
 
   router_configurer.oauth_secret:
     description: "OAuth client secret used to obtain token for Routing API from UAA."
+
+  uaa.token_endpoint:
+    description: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
 
   uaa.tls_port:
     description: "Port on which UAA is listening for TLS connections. This is required for obtaining an OAuth token for Routing API."

--- a/jobs/router_configurer/templates/router_configurer.yml.erb
+++ b/jobs/router_configurer/templates/router_configurer.yml.erb
@@ -1,5 +1,5 @@
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   client_name: "tcp_router"
   client_secret: <%= p("router_configurer.oauth_secret") %>
   port: <%= p("uaa.tls_port") %>
@@ -9,8 +9,8 @@ oauth:
   <% end %>
 
 routing_api:
-  uri: http://routing-api.service.cf.internal
-  port: 3000
+  uri: <%= p("routing_api.uri") %>
+  port: <%= p("routing_api.port") %>
   auth_disabled: <%= p("routing_api.auth_disabled") %>
 
 

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -69,6 +69,10 @@ properties:
     decription : "Certificate authority for communication between clients and UAA."
     default: ""
 
+  uaa.token_endpoint:
+    description: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
+
   uaa.tls_port:
     description: "Port on which UAA is listening for TLS connections. This is required for obtaining a key to verify client OAuth tokens."
 

--- a/jobs/routing-api/templates/routing-api.yml.erb
+++ b/jobs/routing-api/templates/routing-api.yml.erb
@@ -6,7 +6,7 @@ metron_config:
 metrics_reporting_interval: <%= p("routing_api.metrics_reporting_interval") %>
 statsd_endpoint: <%= p("routing_api.statsd_endpoint") %>
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   port: <%= p("uaa.tls_port") %>
   skip_ssl_validation: <%= p("skip_ssl_validation") %>
   <% if p("uaa.ca_cert") != "" %>

--- a/jobs/tcp_emitter/spec
+++ b/jobs/tcp_emitter/spec
@@ -30,6 +30,14 @@ properties:
   tcp_emitter.bbs.client_key:
     description: "PEM-encoded client key"
 
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
+
+  routing_api.port:
+    description: "Port of routing api"
+    default: "3000"
+
   routing_api.auth_disabled:
     description: "auth disabled setting of routing api"
     default: false
@@ -48,6 +56,10 @@ properties:
   skip_ssl_validation:
     description: Skip TLS verification when talking to UAA
     default: false
+
+  uaa.token_endpoint:
+    description: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
 
   uaa.tls_port:
     description: "Port on which UAA is listening for TLS connections. This is required for obtaining a OAuth token for Routing API."

--- a/jobs/tcp_emitter/templates/tcp_emitter.yml.erb
+++ b/jobs/tcp_emitter/templates/tcp_emitter.yml.erb
@@ -1,5 +1,5 @@
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   client_name: "tcp_emitter"
   client_secret: <%= p("tcp_emitter.oauth_secret") %>
   port: <%= p("uaa.tls_port") %>
@@ -8,8 +8,8 @@ oauth:
   ca_certs: "/var/vcap/jobs/tcp_emitter/config/certs/uaa/ca.crt"
   <% end %>
 routing_api:
-  uri: http://routing-api.service.cf.internal
-  port: 3000
+  uri: <%= p("routing_api.uri") %>
+  port: <%= p("routing_api.port") %>
   auth_disabled: <%= p("routing_api.auth_disabled") %>
 
 


### PR DESCRIPTION
Hi there!

This makes it possible to run in configurations where a different service discovery mechanism is involved.  Also cleaned up a couple instances of hard-coded port numbers for routing-api (though it isn't yet possible to make it listen on a different port).

See also PRs where we've done the same for other BOSH releases:
- cloudfoundry/cf-release#915
- cloudfoundry-incubator/etcd-release#9
- cloudfoundry-incubator/diego-release#153
