### PR TITLE
Make tcp-router heathcheck ip and routing-api listen ip configurable

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -21,3 +21,7 @@ properties:
   haproxy.health_check_port:
     description: "Load balancer in front of TCP Routers should be configured to check the health of TCP Router instances by establishing a TCP connection on this port"
     default: 80
+
+  haproxy.health_check_ip:
+    description: "IP for haproxy health check"
+    default: ""

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -18,5 +18,5 @@ defaults
 
 listen health_check_http_url
     mode http
-    bind :<%= p("haproxy.health_check_port") %>
+    bind <%= p("haproxy.health_check_ip") %>:<%= p("haproxy.health_check_port") %>
     monitor-uri /health

--- a/jobs/haproxy/templates/haproxy.conf.template.erb
+++ b/jobs/haproxy/templates/haproxy.conf.template.erb
@@ -18,5 +18,5 @@ defaults
 
 listen health_check_http_url
     mode http
-    bind :<%= p("haproxy.health_check_port") %>
+    bind <%= p("haproxy.health_check_ip") %>:<%= p("haproxy.health_check_port") %>
     monitor-uri /health

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -108,3 +108,7 @@ properties:
   routing_api.lock_retry_interval:
     description: "interval to wait before retrying a failed lock acquisition"
     default: "5s"
+
+  routing_api.listen_ip:
+    description: "IP for routing api to listen on"
+    default: "0.0.0.0"

--- a/jobs/routing-api/templates/routing-api_ctl.erb
+++ b/jobs/routing-api/templates/routing-api_ctl.erb
@@ -57,6 +57,7 @@ case $1 in
          -logLevel=<%= p("routing_api.log_level") %> \
          -ip <%= my_ip %> \
          <% if p("routing_api.auth_disabled") == true %> -devMode <% end %> \
+         <%= p("routing_api.etcd.servers").map{|addr| "#{p("routing_api.etcd.require_ssl") ? "https" : "http"}://#{addr}:4001"}.join(" ")%>
 
     ;;
 


### PR DESCRIPTION
This allows haproxy and routing-api to bind to specific interfaces (i.e. localhost) instead of all interfaces.

Corresponding routing-api PR: https://github.com/cloudfoundry-incubator/routing-api/pull/9

@mdelillo @aemengo 