### PR TITLE
Make haproxy heath check ip and routing listen ip configurable

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -23,6 +23,9 @@ properties:
   router.port:
     description: "Listening Port for Router."
     default: 80
+  router.status.host:
+    description: "Host for the /health, /varz, and /routes endpoints."
+    default: "0.0.0.0"
   router.status.port:
     description: "Port for the /health, /varz, and /routes endpoints."
     default: 8080

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -1,8 +1,10 @@
 ---
-<% if_p("router.status.port",
+<% if_p("router.status.host",
+        "router.status.port",
         "router.status.user",
-        "router.status.password") do |port, user, password| %>
+        "router.status.password") do |host, port, user, password| %>
 status:
+  host: <%= host %>
   port: <%= port %>
   user: <%= user %>
   pass: "<%= password %>"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -21,3 +21,7 @@ properties:
   haproxy.health_check_port:
     description: "Load balancer in front of TCP Routers should be configured to check the health of TCP Router instances by establishing a TCP connection on this port"
     default: 80
+
+  haproxy.health_check_ip:
+    description: "IP for haproxy health check"
+    default: ""

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -23,5 +23,5 @@ properties:
     default: 80
 
   haproxy.health_check_ip:
-    description: "IP for haproxy health check"
-    default: ""
+    description: "Interface on which TCP Router listens for healthchecks"
+    default: "0.0.0.0"

--- a/jobs/haproxy/templates/haproxy.conf.erb
+++ b/jobs/haproxy/templates/haproxy.conf.erb
@@ -18,5 +18,5 @@ defaults
 
 listen health_check_http_url
     mode http
-    bind :<%= p("haproxy.health_check_port") %>
+    bind <%= p("haproxy.health_check_ip") %>:<%= p("haproxy.health_check_port") %>
     monitor-uri /health

--- a/jobs/haproxy/templates/haproxy.conf.template.erb
+++ b/jobs/haproxy/templates/haproxy.conf.template.erb
@@ -18,5 +18,5 @@ defaults
 
 listen health_check_http_url
     mode http
-    bind :<%= p("haproxy.health_check_port") %>
+    bind <%= p("haproxy.health_check_ip") %>:<%= p("haproxy.health_check_port") %>
     monitor-uri /health

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -110,5 +110,5 @@ properties:
     default: "5s"
 
   routing_api.listen_ip:
-    description: "IP for routing api to listen on"
+    description: "Interface on which Routing Api listens"
     default: "0.0.0.0"

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -108,3 +108,7 @@ properties:
   routing_api.lock_retry_interval:
     description: "interval to wait before retrying a failed lock acquisition"
     default: "5s"
+
+  routing_api.listen_ip:
+    description: "IP for routing api to listen on"
+    default: "0.0.0.0"

--- a/jobs/routing-api/templates/routing-api_ctl.erb
+++ b/jobs/routing-api/templates/routing-api_ctl.erb
@@ -57,6 +57,7 @@ case $1 in
          -logLevel=<%= p("routing_api.log_level") %> \
          -ip <%= my_ip %> \
          <% if p("routing_api.auth_disabled") == true %> -devMode <% end %> \
+         <%= p("routing_api.etcd.servers").map{|addr| "#{p("routing_api.etcd.require_ssl") ? "https" : "http"}://#{addr}:4001"}.join(" ")%>
 
     ;;
 


### PR DESCRIPTION
Allows the routing release components' network interfaces to be configurable

This is related to the PR here:
https://github.com/cloudfoundry/gorouter/pull/154