### PR TITLE
Add support for per-instance route registration.

### DIFF
--- a/jobs/route_registrar/spec
+++ b/jobs/route_registrar/spec
@@ -42,7 +42,7 @@ properties:
         routing updates. It must be a time duration represented as a string
         (e.g. "10s").
         It must parse to a positive time duration i.e. "-5s" is not permitted.
-      * Additionally, the 'tags' and 'health_check' keys are optional.
+      * Additionally, the 'tags', 'health_check', and 'prepend_instance_index' keys are optional.
       * 'uris' is an array of URIs to register for the 'port'.
       * 'tags' are included in metrics that gorouter emits to support filtering.
       * 'health_check' is a hash which should have 'name' and 'script_path'.
@@ -57,6 +57,13 @@ properties:
       * if the healthcheck script exits with error, the route is unregistered.
       * if a timeout is configured, the healthcheck script must exit within the timeout,
         otherwise it is terminated (with `SIGKILL`) and the route is unregistered.
+      * 'prepend_instance_index' is a boolean. When set to true the values in 'uris'
+        will be prepended with the instance index.
+        e.g. 'some-uri.system-domain.com' will become '0-some-uri.system-domain.com' on the instance
+        with index 0, and '2-some-url.system-domain.com' on the instance with index 2.
+        When this value is enabled, each instance will register its own, unique, set of uris.
+        To additionally continue to register these original uris, create another route
+        with the same uris and set 'prepend_instance_index' to false (or omit the key entirely).
     example: |
       - name: my-service
         registration_interval: 20s
@@ -75,3 +82,12 @@ properties:
         port: 12346
         uris:
           - my-service.system-domain.com/debug
+      - name: cf-mysql-proxy-api-per-instance
+        port: 8080
+        uris:
+        - proxy-cf-mysql.system.domain
+        prepend_instance_index: true
+      - name: cf-mysql-proxy-api
+        port: 8081
+        uris:
+        - proxy-cf-mysql.system.domain

--- a/jobs/route_registrar/templates/registrar_settings.yml.erb
+++ b/jobs/route_registrar/templates/registrar_settings.yml.erb
@@ -1,4 +1,4 @@
-<%
+<%=
   require 'json'
 
   def discover_external_ip
@@ -18,12 +18,13 @@
 
     network.ip
   end
+  my_ip = discover_external_ip
 
-  nats_machines = nil
-  if_p('nats.machines') do |ips|
-    nats_machines = ips.compact
+  nats_ips = nil
+  if_p('nats.ips') do |ips|
+    nats_ips = ips.compact
   end.else do
-    nats_machines = link('nats').instances.map { |instance| instance.address }
+    nats_ips = link('nats').instances.map { |instance| instance.address }
   end
 
   nats_port = nil
@@ -46,15 +47,27 @@
   end.else do
     nats_password = link('nats').p("nats.password")
   end
+
+  message_bus_servers = nats_ips.map do |ip|
+    {
+      host: "#{ip}:#{nats_port}",
+      user: "#{nats_user}",
+      password: "#{nats_password}"
+    }
+  end
+
+  routes = p('route_registrar.routes')
+
+  routes.each do |route|
+    if route['prepend_instance_index']
+      route['uris'].map! { |uri| "#{spec.index}-#{uri}" }
+    end
+  end
+
+  config = {
+    message_bus_servers: message_bus_servers,
+    host: my_ip,
+    routes: routes,
+  }
+  JSON.pretty_generate(config)
 %>
----
-message_bus_servers:
-<% nats_machines.each do |ip| %>
-    - host: <%= ip %>:<%= nats_port %>
-      user: <%= nats_user %>
-      password: <%= nats_password %>
-<% end %>
-
-routes: <%= p('route_registrar.routes').to_json %>
-
-host: <%= discover_external_ip %>


### PR DESCRIPTION
- This enables routing to a specific instance where round-robin routing
  across each instance of an instance group is not desired.
  A concrete example of this is the proxy in cf-mysql-release, where
  each proxy has a unique HTTP dashboard and so round-robin routing
  across them would return misleading and unhelpful results.

- When a route has the optional 'prepend_instance_index' boolean set to true,
  all URIs for this route will have the instance group index prepended
  to it.
  For example, if the URIs are:
  - foo.system-domain.com
  - bar.system-domain.com
  and the instances have indicies 0 and 2,
  then the URIs registered by the first instance will be:
  - 0-foo.system-domain.com
  - 0-bar.system-domain.com
  and the URIs registered by the second instance will be:
  - 2-foo.system-domain.com
  - 2-bar.system-domain.com
  Neither instance will register the original routes:
  - foo.system-domain.com
  - bar.system-domain.com

[#135377279]

Signed-off-by: Derek Richard <drichard@pivotal.io>