### PR TITLE
Fix default of router.status.port in jobs/gorouter/spec

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -30,7 +30,7 @@ properties:
     default: 80
   router.status.port:
     description: "Port for the /health, /varz, and /routes endpoints."
-    default: 8080
+    default: 8082
   router.status.user:
     description: "Username for HTTP basic auth to the /varz and /routes endpoints."
   router.status.password:


### PR DESCRIPTION
The status port value is described as `8080` in the spec,
but it is actually `8082` in the source code of gorouter.

cf.
* https://github.com/cloudfoundry/gorouter/blob/1d44eeb855da9def0af9c32baef2c9be321d4dd6/config/config.go#L31
  (the commit 1d44eeb is referred from the HEAD of the latest develop branch of routing-release)