### PR TITLE
Provide gorouter link

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -19,6 +19,10 @@ packages:
   - routing_utils
   - gorouter
 
+provides:
+- name: gorouter
+  type: router
+
 consumes:
 - name: nats
   type: nats


### PR DESCRIPTION
Useful for UAA, haproxy, and maybe more

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>

* A short explanation of the proposed change:
gorouter job now provides a link so other jobs can get its addresses (IPs or BOSH DNS)

* An explanation of the use cases your change solves
UAA and haproxy in CF release use the router IPs to register where traffic may be coming from. By getting this information from a link, the deployment manifest is easier to author.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Have a dummy bosh job that consumes the link and writes it to a template. See [bosh links](https://bosh.io/docs/links.html) for more information.

* Expected result after the change
The job's addresses are accessible via link

* Current result before the change
The job's addresses must be explicitly provided in jobs' properties

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests`

* [X] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [X] I have run CF Acceptance Tests on bosh lite
