### PR TITLE
Expose route_services_secret in http-router link

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -22,6 +22,8 @@ packages:
 provides:
   - name: gorouter
     type: http-router
+    properties:
+      - router.route_services_secret
 
 consumes:
 - name: nats


### PR DESCRIPTION
Other jobs in the deployment that use the link will want to have the
secret provided as a link, which will help move to the credential to
CredHub and reduce duplicate operator configuration.

* A short explanation of the proposed change:
  
  Add `router.route_services_secret` to the `http-router` link.

* An explanation of the use cases your change solves
  
  Other jobs in the deployment that need the secret want to be able to consume the secret as a link so the credential can be eventually managed by CredHub and to reduce duplicate operator configuration.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
  
  Use the attached router-link-test-release.zip, which is used like silly-router.zip from #71, but adds a new line for the secret in `file.txt`.

* Expected result after the change
  
  Releases that consume the `http-router` link can get the `route_services_secret`

* Current result before the change
  
  The `route_services_secret` is not accessible via a link

* Links to any other associated PRs
  
  #71

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests`

* [X] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [X] I have run CF Acceptance Tests on bosh lite
