### PR TITLE
DNS host check against uaa instead of consul

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -82,7 +82,7 @@ properties:
     default: TLSv1.2
   router.dns_health_check_host:
       description: "Host to ping for confirmation of DNS resolution, only used when Routing API is enabled"
-      default: "consul.service.cf.internal"
+      default: "uaa.service.cf.internal"
   router.tls_pem:
     description: "Array of private keys and certificates used for TLS handshakes with downstream clients. Each element in the array is an object containing fields 'private_key' and 'cert_chain', each of which supports a PEM block. Required if router.enable_ssl is true."
     example: |

--- a/jobs/gorouter/templates/run_gorouter.erb
+++ b/jobs/gorouter/templates/run_gorouter.erb
@@ -9,7 +9,7 @@ source /var/vcap/packages/routing_utils/syslog_utils.sh
 <% if p("routing_api.enabled") %>
   set +e
 
-  host <%= p("router.dns_health_check_host") %>
+  host -r <%= p("router.dns_health_check_host") %>
   if [[ "0" != "$?" ]]; then
     echo "DNS is not up"
     exit 1

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -69,7 +69,7 @@ properties:
 
   dns_health_check_host:
     description: "Host to ping for confirmation of DNS resolution"
-    default: consul.service.cf.internal
+    default: uaa.service.cf.internal
 
   routing_api.sqldb.host:
     description: "Host for SQL database"

--- a/jobs/routing-api/templates/routing-api_ctl.erb
+++ b/jobs/routing-api/templates/routing-api_ctl.erb
@@ -21,7 +21,7 @@ case $1 in
     tee_output_to_sys_log "${LOG_DIR}" "routing_api"
 
     set +e
-    host <%= p("dns_health_check_host") %>
+    host -r <%= p("dns_health_check_host") %>
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1

--- a/jobs/tcp_emitter/spec
+++ b/jobs/tcp_emitter/spec
@@ -87,7 +87,7 @@ properties:
 
   dns_health_check_host:
     description: "Host to ping for confirmation of DNS resolution"
-    default: consul.service.cf.internal
+    default: uaa.service.cf.internal
 
   metron.port:
     description: "The port used to emit dropsonde messages to the Metron agent."

--- a/jobs/tcp_emitter/templates/tcp_emitter_ctl.erb
+++ b/jobs/tcp_emitter/templates/tcp_emitter_ctl.erb
@@ -34,7 +34,7 @@ case $1 in
 
   start)
     set +e
-    host <%= p("dns_health_check_host") %>
+    host -r <%= p("dns_health_check_host") %>
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1

--- a/jobs/tcp_router/spec
+++ b/jobs/tcp_router/spec
@@ -61,7 +61,7 @@ properties:
 
   dns_health_check_host:
     description: "Host to ping for confirmation of DNS resolution"
-    default: consul.service.cf.internal
+    default: uaa.service.cf.internal
 
   metron.port:
     description: "The port used to emit dropsonde messages to the Metron agent."

--- a/jobs/tcp_router/templates/tcp_router_ctl.erb
+++ b/jobs/tcp_router/templates/tcp_router_ctl.erb
@@ -113,7 +113,7 @@ case $1 in
     echo -n "Starting ${NAME}."
 
     set +e
-    host <%= p("dns_health_check_host") %>
+    host -r <%= p("dns_health_check_host") %>
     if [[ "0" != "$?" ]]; then
       echo "DNS is not up"
       exit 1


### PR DESCRIPTION
 - allows the removal of consul in a bosh-dns environment
 - need to use `host -r` so that bosh-dns can be queried non-recursive

 [#149630533]

Signed-off-by: John Shahid <jvshahid@gmail.com>

Thanks for contributing to 'routing-release'. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests`

* [x] I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [x] I have run CF Acceptance Tests on bosh lite
